### PR TITLE
check vcf header for ##, #CHROM\tPOS and sep='\t' added to MyHeritage reader

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -177,7 +177,7 @@ class Reader:
             d = self.read_generic(file, compression)
         elif re.match("^rs[0-9]*[, \t]{1}[1]", first_line):
             d = self.read_generic(file, compression, skip=0)
-        elif ("##" in first_line and "vcf" in comments.lower() and "#CHROM" in comments.lower()) or "##contig" in comments.lower():
+        elif ("##" in first_line and "vcf" in comments.lower() and "#CHROM\tPOS" in comments) or "##contig" in comments.lower():
             d = self.read_vcf(file, compression, "vcf", self._rsids)
         elif ("Genes for Good" in comments) | ("PLINK" in comments):
             d = self.read_genes_for_good(file, compression)

--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -177,7 +177,7 @@ class Reader:
             d = self.read_generic(file, compression)
         elif re.match("^rs[0-9]*[, \t]{1}[1]", first_line):
             d = self.read_generic(file, compression, skip=0)
-        elif "vcf" in comments.lower() or "##contig" in comments.lower():
+        elif "##" in first_line and "vcf" in comments.lower() or "##contig" in comments.lower():
             d = self.read_vcf(file, compression, "vcf", self._rsids)
         elif ("Genes for Good" in comments) | ("PLINK" in comments):
             d = self.read_genes_for_good(file, compression)

--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -177,7 +177,7 @@ class Reader:
             d = self.read_generic(file, compression)
         elif re.match("^rs[0-9]*[, \t]{1}[1]", first_line):
             d = self.read_generic(file, compression, skip=0)
-        elif "##" in first_line and "vcf" in comments.lower() or "##contig" in comments.lower():
+        elif ("##" in first_line and "vcf" in comments.lower() and "#CHROM" in comments.lower()) or "##contig" in comments.lower():
             d = self.read_vcf(file, compression, "vcf", self._rsids)
         elif ("Genes for Good" in comments) | ("PLINK" in comments):
             d = self.read_genes_for_good(file, compression)
@@ -735,6 +735,7 @@ class Reader:
                     io.StringIO(file_string_out.getvalue()),
                     comment="#",
                     header=0,
+                    sep='\t',
                     na_values="--",
                     names=["rsid", "chrom", "pos", "genotype"],
                     index_col=0,


### PR DESCRIPTION
snps output contains vcf in header of txt delimited file. VCF standard is that first line starts with ##, distinguishing a true vcf from a txt file with source=vcf.