### PR TITLE
fix: fga build incorrectly detected

### DIFF
--- a/src/snps/io/reader.py
+++ b/src/snps/io/reader.py
@@ -1505,7 +1505,7 @@ class Reader:
                         compression=compression,
                     )
                     df["chrom"] = df["chrom"].map(CHROMOSOME_FGA)
-            return (df,)
+            return (df, False, 38)  # incorrectly detects build as 37
 
         return self.read_helper("fga", parser)
 


### PR DESCRIPTION
snps incorrectly detects fga files as build 37, saving the vcf using the reference for build 37, which tricks Picard into shifting snps into the wrong position because all snps have build 37 coordinates