### PR TITLE
fix: remove SelfDecode from output

### DIFF
--- a/src/snps/io/writer.py
+++ b/src/snps/io/writer.py
@@ -124,10 +124,7 @@ class Writer:
 
         comment = (
             f"# Pipeline Version: {self._kwargs.pop('pipeline_version')}\n"
-            f"# Source: SelfDecode\n"
             f"# Assembly: GRCh{self._snps.build}\n"
-            # f"# Build Detected: { self._snps.build_detected}\n"
-            # f"# Phased: {self._snps.phased}\n"
             f"# SNPs: {self._snps.count}\n"
             f"# Chromosomes: {self._snps.chromosomes_summary_output}\n"
             f"# Sex: {self._snps.sex}\n"


### PR DESCRIPTION
Removing SelfDecode from txt output for compatibility with white labeling and B2B partners